### PR TITLE
Add a missing 'delete-selection property

### DIFF
--- a/nameless.el
+++ b/nameless.el
@@ -194,6 +194,8 @@ configured, or if `nameless-current-name' is nil."
     (or (nameless-insert-name 'noerror)
         (call-interactively #'self-insert-command))))
 
+(put 'nameless-insert-name-or-self-insert 'delete-selection t)
+
 (defun nameless--name-regexp (name)
   "Return a regexp of the current name."
   (concat "\\_<@?\\(" (regexp-quote name) "-\\)\\(\\s_\\|\\sw\\)"))


### PR DESCRIPTION
From the docs of delete-selection-mode:

;; Commands which will delete the selection need a 'delete-selection
;; property on their symbols; commands which insert text but don't
;; have this property won't delete the selection.
