### PR TITLE
Expand docstring.

### DIFF
--- a/nameless.el
+++ b/nameless.el
@@ -229,7 +229,9 @@ configured, or if `nameless-current-name' is nil."
         (user-error "No name for current buffer, see `nameless-current-name'")))))
 
 (defun nameless-insert-name-or-self-insert (&optional self-insert)
-  "Insert the name of current package, with a hyphen."
+  "Insert the name of current package, with a hyphen.
+If point is in an argument list, or if we're typing an escaped
+character, insert the current character literally instead."
   (interactive "P")
   (let ((l (point)))
     (call-interactively #'self-insert-command)


### PR DESCRIPTION
Previously, it wasn't clear how `nameless-insert-name-or-self-insert`
was different from `nameless-insert-name`, so describe when we self
insert.
