### PR TITLE
[Fix #24] Run nameless--after-hack-local-variables just once

### DIFF
--- a/nameless.el
+++ b/nameless.el
@@ -288,7 +288,8 @@ Return S."
                 (replace-regexp-in-string "\\(-mode\\)?\\(-tests?\\)?\\.[^.]*\\'" "" (lm-get-package-name))))
         (add-function :filter-return (local 'filter-buffer-substring-function)
                       #'nameless--filter-string)
-        (nameless--after-hack-local-variables)
+        (when (called-interactively-p 'any)
+          (nameless--after-hack-local-variables))
         (add-hook 'hack-local-variables-hook
                   #'nameless--after-hack-local-variables
                   nil 'local))


### PR DESCRIPTION
The suggested use of nameless is

  (add-hook 'emacs-lisp-mode-hook #'nameless-mode)

Prior to this change, running nameless in this way would cause
`nameless--after-hack-local-variables` to get run twice on opening a
file: once when running `run-hooks`, and once again when running
`hack-local-variables-hook`. This operation is slow on large files,
and running it twice is even slower.

You might think that it would suffice to simply remove the direct call
to `nameless--after-hack-local-variables` in `nameless-mode`, but then
`nameless-mode` would fail to "toggle" when run interactively.
Instead, we just check whether the function is being called
interatively, "toggling" if it is, then add the function to
`hack-local-variables-hook`. There are probably more elegant ways to
do this, but the basic idea is probably the same in all cases.

To time this change, I used

```
(defun nameless-benchmark ()
  (interactive)
  (benchmark 5 '(progn
                  (find-file "~/emacs/lisp/org/org.el")
                  (kill-buffer "org.el"))))
```

(`org.el` is just shy of 25_000 lines.)

Here are the results of running that twice on master and twice with
this change (times recorded on my crappy little Thinkpad):

* Before
```
Elapsed time: 107.945053s (34.001933s in 213 GCs)
Elapsed time: 107.498577s (33.706725s in 215 GCs)
```

* After
```
Elapsed time: 56.372983s (18.334976s in 115 GCs)
Elapsed time: 56.753919s (18.720507s in 116 GCs)
```

The time is cut in half. This is not surprising, as the expensive
operation is being executed half as often.