### PR TITLE
Change customize :group to 'tools

### DIFF
--- a/nameless.el
+++ b/nameless.el
@@ -44,7 +44,7 @@
 
 (defgroup nameless nil
   "Customization group for nameless."
-  :group 'emacs)
+  :group 'tools)
 
 (defcustom nameless-prefix ":"
   "Prefix displayed instead of package namespace."


### PR DESCRIPTION
Please consider putting nameless in a more logical place within the customize hierarchy. Thanks.